### PR TITLE
Use UTC time instead of local time

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ module.exports = function datetimeDiff (from, to) {
         from = temp;
     }
 
-    let start = [from.getFullYear(), from.getMonth() + 1, from.getDate(), from.getHours(),
-            from.getMinutes(), from.getSeconds(), from.getMilliseconds()],
-        end = [to.getFullYear(), to.getMonth() + 1, to.getDate(), to.getHours(), to.getMinutes(),
-            to.getSeconds(), to.getMilliseconds()],
+    let start = [from.getUTCFullYear(), from.getUTCMonth() + 1, from.getUTCDate(), from.getUTCHours(),
+            from.getUTCMinutes(), from.getUTCSeconds(), from.getUTCMilliseconds()],
+        end = [to.getUTCFullYear(), to.getUTCMonth() + 1, to.getUTCDate(), to.getUTCHours(), to.getUTCMinutes(),
+            to.getUTCSeconds(), to.getUTCMilliseconds()],
         i = 7;
 
     const dec = (i) => {
@@ -25,7 +25,7 @@ module.exports = function datetimeDiff (from, to) {
                 ? r
                 : max[i];
         }
-        return i === 1 ? new Date(end[0], end[1], 0).getDate() : max[i + 1];
+        return i === 1 ? new Date(Date.UTC(end[0], end[1], 0)).getUTCDate() : max[i + 1];
     };
 
     while (i > 0) {

--- a/test.js
+++ b/test.js
@@ -14,8 +14,8 @@ const expect = (expectedValue) => Object.assign({
 test(`Works with two slightly different dates in seconds`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 0, 1, 0, 0, 0),
-        new Date(2017, 0, 1, 0, 0, 1)
+        new Date(Date.UTC(2017, 0, 1, 0, 0, 0)),
+        new Date(Date.UTC(2017, 0, 1, 0, 0, 1))
     );
 
     it.deepEqual(result, expect({ seconds: 1 }));
@@ -25,8 +25,8 @@ test(`Works with two slightly different dates in seconds`, (it) => {
 test(`Works with two slightly different dates in minutes`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 0, 1, 0, 0, 0),
-        new Date(2017, 0, 1, 0, 1, 0)
+        new Date(Date.UTC(2017, 0, 1, 0, 0, 0)),
+        new Date(Date.UTC(2017, 0, 1, 0, 1, 0))
     );
 
     it.deepEqual(result, expect({ minutes: 1 }));
@@ -36,8 +36,8 @@ test(`Works with two slightly different dates in minutes`, (it) => {
 test(`Works with two slightly different dates in hours`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 0, 1, 1, 0, 0),
-        new Date(2017, 0, 1, 3, 0, 0)
+        new Date(Date.UTC(2017, 0, 1, 1, 0, 0)),
+        new Date(Date.UTC(2017, 0, 1, 3, 0, 0))
     );
 
     it.deepEqual(result, expect({ hours: 2 }));
@@ -47,8 +47,8 @@ test(`Works with two slightly different dates in hours`, (it) => {
 test(`Works with two slightly different dates in days`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 0, 1, 1, 0, 0),
-        new Date(2017, 0, 3, 1, 0, 0)
+        new Date(Date.UTC(2017, 0, 1, 1, 0, 0)),
+        new Date(Date.UTC(2017, 0, 3, 1, 0, 0))
     );
 
     it.deepEqual(result, expect({ days: 2 }));
@@ -58,8 +58,8 @@ test(`Works with two slightly different dates in days`, (it) => {
 test(`Works with two slightly different dates in months`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 3, 1, 1, 0, 0),
-        new Date(2017, 5, 1, 1, 0, 0)
+        new Date(Date.UTC(2017, 3, 1, 1, 0, 0)),
+        new Date(Date.UTC(2017, 5, 1, 1, 0, 0))
     );
 
     it.deepEqual(result, expect({ months: 2 }));
@@ -69,8 +69,8 @@ test(`Works with two slightly different dates in months`, (it) => {
 test(`Works with two slightly different dates in years`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2013, 3, 1, 1, 0, 0),
-        new Date(2019, 3, 1, 1, 0, 0)
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0)),
+        new Date(Date.UTC(2019, 3, 1, 1, 0, 0))
     );
 
     it.deepEqual(result, expect({ years: 6 }));
@@ -80,8 +80,8 @@ test(`Works with two slightly different dates in years`, (it) => {
 test(`Works with two slightly different dates in milliseconds`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2013, 3, 1, 1, 0, 0, 500),
-        new Date(2013, 3, 1, 1, 0, 0, 700)
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0, 500)),
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0, 700))
     );
 
     it.deepEqual(result, expect({ milliseconds: 200 }));
@@ -91,8 +91,8 @@ test(`Works with two slightly different dates in milliseconds`, (it) => {
 test(`Works with inverted date case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2013, 3, 1, 1, 0, 0, 500),
-        new Date(2013, 3, 1, 1, 0, 0, 100)
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0, 500)),
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0, 100))
     );
 
     it.deepEqual(result, expect({ milliseconds: 400 }));
@@ -102,8 +102,8 @@ test(`Works with inverted date case`, (it) => {
 test(`Works with inverted date complex case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2013, 3, 1, 1, 0, 0, 500),
-        new Date(2013, 5, 1, 1, 30, 0, 100)
+        new Date(Date.UTC(2013, 3, 1, 1, 0, 0, 500)),
+        new Date(Date.UTC(2013, 5, 1, 1, 30, 0, 100))
     );
 
     it.deepEqual(result, expect({
@@ -118,8 +118,8 @@ test(`Works with inverted date complex case`, (it) => {
 test(`New year case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 11, 30, 12, 0, 0),
-        new Date(2017, 0, 2, 6, 0, 59, 25)
+        new Date(Date.UTC(2016, 11, 30, 12, 0, 0)),
+        new Date(Date.UTC(2017, 0, 2, 6, 0, 59, 25))
     );
 
     it.deepEqual(result, expect({
@@ -134,8 +134,8 @@ test(`New year case`, (it) => {
 test(`February case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 1, 28, 12, 0, 0),
-        new Date(2017, 2, 1, 0, 0, 0)
+        new Date(Date.UTC(2017, 1, 28, 12, 0, 0)),
+        new Date(Date.UTC(2017, 2, 1, 0, 0, 0))
     );
 
     it.deepEqual(result, expect({
@@ -147,8 +147,8 @@ test(`February case`, (it) => {
 test(`Quarter case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2017, 2, 3, 14, 0, 0),
-        new Date(2017, 5, 4, 12, 0, 0)
+        new Date(Date.UTC(2017, 2, 3, 14, 0, 0)),
+        new Date(Date.UTC(2017, 5, 4, 12, 0, 0))
     );
 
     it.deepEqual(result, expect({
@@ -161,8 +161,8 @@ test(`Quarter case`, (it) => {
 test(`Complex new year case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 11, 17, 3, 23, 55),
-        new Date(2017, 0, 14, 7, 24, 11)
+        new Date(Date.UTC(2016, 11, 17, 3, 23, 55)),
+        new Date(Date.UTC(2017, 0, 14, 7, 24, 11))
     );
 
     it.deepEqual(result, expect({
@@ -176,8 +176,8 @@ test(`Complex new year case`, (it) => {
 test(`Complex new year case`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 11, 17, 3, 23, 55),
-        new Date(2017, 0, 14, 7, 24, 11)
+        new Date(Date.UTC(2016, 11, 17, 3, 23, 55)),
+        new Date(Date.UTC(2017, 0, 14, 7, 24, 11))
     );
 
     it.deepEqual(result, expect({
@@ -191,8 +191,8 @@ test(`Complex new year case`, (it) => {
 test(`Years far difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 1, 1),
-        new Date(2026, 1, 1)
+        new Date(Date.UTC(2016, 1, 1)),
+        new Date(Date.UTC(2026, 1, 1))
     );
 
     it.deepEqual(result, expect({
@@ -204,8 +204,8 @@ test(`Years far difference`, (it) => {
 test(`Leap year close difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 1, 28),
-        new Date(2016, 2, 1)
+        new Date(Date.UTC(2016, 1, 28)),
+        new Date(Date.UTC(2016, 2, 1))
     );
 
     it.deepEqual(result, expect({
@@ -217,8 +217,8 @@ test(`Leap year close difference`, (it) => {
 test(`Leap year one-month difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 1, 25),
-        new Date(2016, 2, 25)
+        new Date(Date.UTC(2016, 1, 25)),
+        new Date(Date.UTC(2016, 2, 25))
     );
 
     it.deepEqual(result, expect({
@@ -230,8 +230,8 @@ test(`Leap year one-month difference`, (it) => {
 test(`Just one-month difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 3, 15),
-        new Date(2016, 4, 15)
+        new Date(Date.UTC(2016, 3, 15)),
+        new Date(Date.UTC(2016, 4, 15))
     );
 
     it.deepEqual(result, expect({
@@ -243,8 +243,8 @@ test(`Just one-month difference`, (it) => {
 test(`One month and some days difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 3, 15),
-        new Date(2016, 4, 17)
+        new Date(Date.UTC(2016, 3, 15)),
+        new Date(Date.UTC(2016, 4, 17))
     );
 
     it.deepEqual(result, expect({
@@ -257,8 +257,8 @@ test(`One month and some days difference`, (it) => {
 test(`One month and some days difference on another month`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 4, 15),
-        new Date(2016, 5, 17)
+        new Date(Date.UTC(2016, 4, 15)),
+        new Date(Date.UTC(2016, 5, 17))
     );
 
     it.deepEqual(result, expect({
@@ -271,8 +271,8 @@ test(`One month and some days difference on another month`, (it) => {
 test(`~ 364 days difference`, (it) => {
 
     const result = datetimeDiff(
-        new Date(2016, 4, 15),
-        new Date(2017, 4, 14)
+        new Date(Date.UTC(2016, 4, 15)),
+        new Date(Date.UTC(2017, 4, 14))
     );
 
     it.deepEqual(result, expect({
@@ -280,4 +280,18 @@ test(`~ 364 days difference`, (it) => {
         months: 11
     }));
 
+});
+
+test(`Dates before and after a DST change`, (it) => {
+    // This test can only fail when the local time is on a timezone with daylight saving time in effect
+    // It's not really reliable, but it's good for documentation purposes.
+    const result = datetimeDiff(
+        new Date(1540807205042),
+        new Date(1540360805042)
+    );
+
+    it.deepEqual(result, expect({
+        days: 5,
+        hours: 4
+    }))
 });


### PR DESCRIPTION
If the local time is in a timezone that has DST in effect (e.g. Europe/Bucharest - UTC +2 in summer vs UTC +3 in winter), `datetimeDifference` produces wrong results when the input dates are before and respectively after the DST hour change.

Changing all usages of `Date` methods to their UTC counterparts ensures predictable results regardless of timezone.